### PR TITLE
Updates stream message emote columns to json

### DIFF
--- a/database_report_generator/src/chat_statistics.rs
+++ b/database_report_generator/src/chat_statistics.rs
@@ -6,6 +6,7 @@ use entities::donation_event;
 use entities::sea_orm_active_enums::EventType;
 use entities::stream_message;
 use entities::subscription_event;
+use entity_extensions::prelude::StreamMessageExtensions;
 use sea_orm::*;
 use std::collections::HashMap;
 use subscriptions::Subscriptions;
@@ -152,33 +153,11 @@ impl ChatStatistics {
         continue;
       };
 
-      let twitch_emotes_used = message.twitch_emote_usage.as_deref().unwrap_or("{}");
-      let twitch_emotes_used =
-        match serde_json::from_str::<HashMap<String, usize>>(twitch_emotes_used) {
-          Ok(twitch_emotes_used) => twitch_emotes_used.values().sum::<usize>(),
-          Err(error) => {
-            tracing::error!(
-              "Failed to parse the Twitch emotes used for a message. Message ID: {}. Reason: {:?}",
-              message.id,
-              error
-            );
-            continue;
-          }
-        };
-
-      let third_party_emotes = message.third_party_emotes_used.as_deref().unwrap_or("{}");
-      let third_party_emotes_used =
-        match serde_json::from_str::<HashMap<String, usize>>(third_party_emotes) {
-          Ok(third_party_emotes) => third_party_emotes.values().sum::<usize>(),
-          Err(error) => {
-            tracing::error!(
-              "Failed to parse the third party emotes for message. Message ID: {}. Reason: {:?}",
-              message.id,
-              error
-            );
-            continue;
-          }
-        };
+      let twitch_emotes_used = message.get_twitch_emotes_used().values().sum::<usize>();
+      let third_party_emotes_used = message
+        .get_third_party_emotes_used()
+        .values()
+        .sum::<usize>();
 
       let total_emotes_used = twitch_emotes_used + third_party_emotes_used;
 

--- a/database_report_generator/src/templates/chat_messages.rs
+++ b/database_report_generator/src/templates/chat_messages.rs
@@ -3,6 +3,7 @@ use crate::errors::AppError;
 use crate::EMOTE_DOMINANCE;
 use database_connection::get_database_connection;
 use entities::{stream_message, twitch_user};
+use entity_extensions::prelude::StreamMessageExtensions;
 use sea_orm::*;
 use std::collections::HashMap;
 use tabled::settings::Style;
@@ -152,33 +153,11 @@ fn emote_filtered_messages(messages: Vec<&stream_message::Model>) -> Vec<&stream
         );
         return false;
       };
-      let twitch_emotes_used = message.twitch_emote_usage.as_deref().unwrap_or("{}");
-      let twitch_emotes_used =
-        match serde_json::from_str::<HashMap<String, usize>>(twitch_emotes_used) {
-          Ok(twitch_emotes_used) => twitch_emotes_used.values().sum::<usize>(),
-          Err(error) => {
-            tracing::error!(
-              "Failed to parse the Twitch emotes used for a message. Message ID: {}. Reason: {:?}",
-              message.id,
-              error
-            );
-            return false;
-          }
-        };
-
-      let third_party_emotes = message.third_party_emotes_used.as_deref().unwrap_or("{}");
-      let third_party_emotes_used =
-        match serde_json::from_str::<HashMap<String, usize>>(third_party_emotes) {
-          Ok(third_party_emotes) => third_party_emotes.values().sum::<usize>(),
-          Err(error) => {
-            tracing::error!(
-              "Failed to parse the third party emotes for message. Message ID: {}. Reason: {:?}",
-              message.id,
-              error
-            );
-            return false;
-          }
-        };
+      let twitch_emotes_used = message.get_twitch_emotes_used().values().sum::<usize>();
+      let third_party_emotes_used = message
+        .get_third_party_emotes_used()
+        .values()
+        .sum::<usize>();
 
       let total_emotes_used = twitch_emotes_used + third_party_emotes_used;
 

--- a/entities/src/stream_message.rs
+++ b/entities/src/stream_message.rs
@@ -15,11 +15,9 @@ pub struct Model {
   pub twitch_user_id: i32,
   pub channel_id: i32,
   pub stream_id: Option<i32>,
-  #[sea_orm(column_type = "Text", nullable)]
-  pub third_party_emotes_used: Option<String>,
+  pub third_party_emotes_used: Option<Json>,
   pub is_subscriber: i8,
-  #[sea_orm(column_type = "Text", nullable)]
-  pub twitch_emote_usage: Option<String>,
+  pub twitch_emote_usage: Option<Json>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/entity_extensions/src/stream_message.rs
+++ b/entity_extensions/src/stream_message.rs
@@ -8,54 +8,98 @@ pub trait StreamMessageExtensions {
 
 impl StreamMessageExtensions for stream_message::Model {
   fn get_twitch_emotes_used(&self) -> HashMap<i32, usize> {
-    let twitch_emotes_used = self.twitch_emote_usage.as_deref().unwrap_or("{}");
-    let twitch_emotes_used =
-      match serde_json::from_str::<HashMap<String, usize>>(twitch_emotes_used) {
-        Ok(twitch_emotes_used) => twitch_emotes_used,
-        Err(error) => {
-          tracing::error!(
-            "Failed to parse the Twitch emotes used for a message. Message ID: {}. Reason: {:?}",
-            self.id,
-            error
-          );
-          return HashMap::new();
-        }
-      };
+    let Some(twitch_emotes_used) = self.twitch_emote_usage.clone() else {
+      return HashMap::default();
+    };
 
-    twitch_emotes_used
-      .into_iter()
-      .filter_map(|(id_string, usage)| {
-        let id = match id_string.parse::<i32>() {
-          Ok(id) => id,
-          Err(error) => {
-            tracing::error!(
-              "Failed to parse the id of an emote. Id value: {:?}. Reason: {}",
-              id_string,
-              error
-            );
-            return None;
-          }
-        };
-
-        Some((id, usage))
-      })
-      .collect()
-  }
-
-  fn get_third_party_emotes_used(&self) -> HashMap<String, usize> {
-    let third_party_emotes = self.third_party_emotes_used.as_deref().unwrap_or("{}");
-
-    match serde_json::from_str::<HashMap<String, usize>>(third_party_emotes) {
-      Ok(third_party_emotes) => third_party_emotes,
+    match serde_json::from_value(twitch_emotes_used) {
+      Ok(twitch_emotes) => twitch_emotes,
       Err(error) => {
         tracing::error!(
-          "Failed to parse the third party emotes for message. Message ID: {}. Reason: {:?}",
+          "Failed to parse the Twitch emotes for a message. Message ID: {}. Reason: {:?}, Value: {:?}",
           self.id,
-          error
+          error,
+          self.twitch_emote_usage,
         );
 
         HashMap::new()
       }
     }
+  }
+
+  fn get_third_party_emotes_used(&self) -> HashMap<String, usize> {
+    let Some(third_party_emotes) = self.third_party_emotes_used.clone() else {
+      return HashMap::default();
+    };
+
+    match serde_json::from_value::<HashMap<String, usize>>(third_party_emotes) {
+      Ok(third_party_emotes) => third_party_emotes,
+      Err(error) => {
+        tracing::error!(
+          "Failed to parse the third party emotes for a message. Message ID: {}. Reason: {:?}, Value: {:?}",
+          self.id,
+          error,
+          self.third_party_emotes_used
+        );
+
+        HashMap::new()
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use chrono::{TimeZone, Utc};
+  use serde_json::json;
+
+  #[test]
+  fn stream_message_get_emotes_used_methods_return_expected_values() {
+    let stream_message_instance = stream_message::Model {
+      id: 0,
+      is_first_message: 0,
+      timestamp: Utc.with_ymd_and_hms(2025, 2, 16, 12, 18, 25).unwrap(),
+      emote_only: 0,
+      contents: Some("@5EVEN5 syadouGAGAGA GAGAGA".to_string()),
+      twitch_user_id: 3,
+      channel_id: 1,
+      stream_id: None,
+      third_party_emotes_used: Some(json!({"GAGAGA": 1})),
+      is_subscriber: 1,
+      twitch_emote_usage: Some(json!({"7": 1})),
+    };
+
+    let twitch_emotes_used = stream_message_instance.get_twitch_emotes_used();
+    let third_party_emotes_used = stream_message_instance.get_third_party_emotes_used();
+
+    assert_eq!(twitch_emotes_used, HashMap::from([(7, 1)]));
+    assert_eq!(
+      third_party_emotes_used,
+      HashMap::from([("GAGAGA".into(), 1)])
+    );
+  }
+
+  #[test]
+  fn stream_message_get_emotes_used_methods_return_nothing_on_null_value() {
+    let stream_message_instance = stream_message::Model {
+      id: 0,
+      is_first_message: 0,
+      timestamp: Utc.with_ymd_and_hms(2025, 2, 16, 12, 18, 25).unwrap(),
+      emote_only: 0,
+      contents: Some("".to_string()),
+      twitch_user_id: 3,
+      channel_id: 1,
+      stream_id: None,
+      third_party_emotes_used: None,
+      is_subscriber: 1,
+      twitch_emote_usage: None,
+    };
+
+    let twitch_emotes_used = stream_message_instance.get_twitch_emotes_used();
+    let third_party_emotes_used = stream_message_instance.get_third_party_emotes_used();
+
+    assert!(twitch_emotes_used.is_empty());
+    assert!(third_party_emotes_used.is_empty());
   }
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -21,6 +21,7 @@ mod m20250310_202954_create_twitch_user_unknown_user_association_table;
 mod m20250402_182948_create_user_name_change_table;
 mod m20250419_164430_change_stream_message_content_to_utf8mb4;
 mod m20250419_220750_add_twitch_origin_id_column_to_donation_event_table;
+mod m20250514_231010_change_stream_message_emote_columns_to_json_from_strings;
 
 pub struct Migrator;
 
@@ -28,29 +29,28 @@ pub struct Migrator;
 impl MigratorTrait for Migrator {
   fn migrations() -> Vec<Box<dyn MigrationTrait>> {
     vec![
-      Box::new(m20250210_025922_twitch_user_table::Migration),
-      Box::new(m20250210_030348_stream_table::Migration),
-      Box::new(m20250210_030628_stream_message_table::Migration),
-      Box::new(m20250210_033251_emote_table::Migration),
-      Box::new(m20250210_033303_stream_message_emote_table::Migration),
-      Box::new(m20250210_034946_stream_name_table::Migration),
-      Box::new(m20250210_035251_donation_event_table::Migration),
-      Box::new(m20250210_043325_subscription_event_table::Migration),
-      Box::new(m20250210_204036_user_timeout_table::Migration),
-      Box::new(m20250212_180158_add_sub_tier_column_to_donation_event_table::Migration),
-      Box::new(m20250212_201344_add_sub_tier_column_to_subscription_event_table::Migration),
-      Box::new(
-        m20250213_174031_add_third_party_emotes_used_column_to_stream_message_table::Migration,
-      ),
-      Box::new(m20250213_193501_update_stream_message_table_stream_id_to_be_nullable::Migration),
-      Box::new(m20250215_052013_add_is_subscriber_column_to_stream_message_table::Migration),
-      Box::new(m20250218_202933_add_twitch_emote_usage_column_to_stream_message_table::Migration),
-      Box::new(m20250224_065519_add_raid_table::Migration),
-      Box::new(m20250309_012925_update_donation_event_to_have_optional_name_field::Migration),
-      Box::new(m20250310_202954_create_twitch_user_unknown_user_association_table::Migration),
-      Box::new(m20250402_182948_create_user_name_change_table::Migration),
-      Box::new(m20250419_164430_change_stream_message_content_to_utf8mb4::Migration),
-      Box::new(m20250419_220750_add_twitch_origin_id_column_to_donation_event_table::Migration),
-    ]
+            Box::new(m20250210_025922_twitch_user_table::Migration),
+            Box::new(m20250210_030348_stream_table::Migration),
+            Box::new(m20250210_030628_stream_message_table::Migration),
+            Box::new(m20250210_033251_emote_table::Migration),
+            Box::new(m20250210_033303_stream_message_emote_table::Migration),
+            Box::new(m20250210_034946_stream_name_table::Migration),
+            Box::new(m20250210_035251_donation_event_table::Migration),
+            Box::new(m20250210_043325_subscription_event_table::Migration),
+            Box::new(m20250210_204036_user_timeout_table::Migration),
+            Box::new(m20250212_180158_add_sub_tier_column_to_donation_event_table::Migration),
+            Box::new(m20250212_201344_add_sub_tier_column_to_subscription_event_table::Migration),
+            Box::new(m20250213_174031_add_third_party_emotes_used_column_to_stream_message_table::Migration),
+            Box::new(m20250213_193501_update_stream_message_table_stream_id_to_be_nullable::Migration),
+            Box::new(m20250215_052013_add_is_subscriber_column_to_stream_message_table::Migration),
+            Box::new(m20250218_202933_add_twitch_emote_usage_column_to_stream_message_table::Migration),
+            Box::new(m20250224_065519_add_raid_table::Migration),
+            Box::new(m20250309_012925_update_donation_event_to_have_optional_name_field::Migration),
+            Box::new(m20250310_202954_create_twitch_user_unknown_user_association_table::Migration),
+            Box::new(m20250402_182948_create_user_name_change_table::Migration),
+            Box::new(m20250419_164430_change_stream_message_content_to_utf8mb4::Migration),
+            Box::new(m20250419_220750_add_twitch_origin_id_column_to_donation_event_table::Migration),
+            Box::new(m20250514_231010_change_stream_message_emote_columns_to_json_from_strings::Migration),
+        ]
   }
 }

--- a/migration/src/m20250514_231010_change_stream_message_emote_columns_to_json_from_strings.rs
+++ b/migration/src/m20250514_231010_change_stream_message_emote_columns_to_json_from_strings.rs
@@ -10,14 +10,19 @@ impl MigrationTrait for Migration {
       .alter_table(
         Table::alter()
           .table(StreamMessage::Table)
-          .add_column(
+          .modify_column(
+            ColumnDef::new(StreamMessage::ThirdPartyEmotesUsed)
+              .json()
+              .to_owned(),
+          )
+          .modify_column(
             ColumnDef::new(StreamMessage::TwitchEmoteUsage)
-              .text()
-              .null(),
+              .json()
+              .to_owned(),
           )
           .to_owned(),
       )
-    .await
+      .await
   }
 
   async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
@@ -25,10 +30,19 @@ impl MigrationTrait for Migration {
       .alter_table(
         Table::alter()
           .table(StreamMessage::Table)
-          .drop_column(StreamMessage::TwitchEmoteUsage)
+          .modify_column(
+            ColumnDef::new(StreamMessage::ThirdPartyEmotesUsed)
+              .string()
+              .to_owned(),
+          )
+          .modify_column(
+            ColumnDef::new(StreamMessage::TwitchEmoteUsage)
+              .string()
+              .to_owned(),
+          )
           .to_owned(),
       )
-    .await
+      .await
   }
 }
 
@@ -44,7 +58,7 @@ enum StreamMessage {
   _Timestamp,
   _EmoteOnly,
   _Contents,
-  _ThirdPartyEmotesUsed,
+  ThirdPartyEmotesUsed,
   _IsSubscriber,
   TwitchEmoteUsage,
 }


### PR DESCRIPTION
In order to maintain clarity and to extend the use of queries for said columns, this commit converts the `third_party_emotes_used` and `twitch_emote_usage` from strings to json. Any instance of these columns being used has been fixed to work, and tests were made to ensure values are being returned as expected.