### PR TITLE
Adds a heartbeat message to IRC config

### DIFF
--- a/src/processes/main_process.rs
+++ b/src/processes/main_process.rs
@@ -3,6 +3,7 @@ use crate::irc_chat::twitch_irc::TwitchIrc;
 use std::time::Duration;
 use tokio::{sync::mpsc, task::JoinHandle};
 
+#[allow(unreachable_code)]
 pub async fn run_main_process(
   message_result_processor_sender: mpsc::UnboundedSender<JoinHandle<Result<(), AppError>>>,
 ) {
@@ -44,4 +45,6 @@ pub async fn run_main_process(
       _ => (),
     }
   }
+
+  panic!("Main processes ended expectedly.");
 }


### PR DESCRIPTION
In order to debug the app losing all life randomly, this commit adds a heartbeat to check for next time if the app is running at all in the event of this mysterious disconnect.