### PR TITLE
Adds directly searching login on follower search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ bin/update
 temp_*
 *.fsh
 *.db
+ingress*
+*env.production

--- a/backend/src/data_transfer_objects/follow.rs
+++ b/backend/src/data_transfer_objects/follow.rs
@@ -20,7 +20,7 @@ pub struct Follow {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct FollowResponse {
   #[serde(rename = "forUser")]
-  pub for_user: twitch_user::Model,
+  pub for_user: Option<twitch_user::Model>,
 
   pub follows: Vec<Follow>,
 }

--- a/backend/src/routes/users/following.rs
+++ b/backend/src/routes/users/following.rs
@@ -23,14 +23,18 @@ pub async fn get_following(
 ) -> Result<axum::Json<FollowResponse>, AppError> {
   tracing::info!("Got a following request: {query_payload:?}");
 
-  let Some(user) = query_payload
+  let user = query_payload
     .get_user_query()?
     .one(interface_config.database_connection())
-    .await?
-  else {
-    return Err(query_payload.get_missing_user_error());
+    .await?;
+  let user_login = if let Some(user) = &user {
+    &user.login_name
+  } else {
+    match &query_payload.maybe_login {
+      Some(maybe_login) => maybe_login.as_str(),
+      None => return Err(query_payload.get_missing_user_error()),
+    }
   };
-  let user_login = &user.login_name;
 
   tracing::info!("Got a user for the following request: {user_login:?}");
 

--- a/frontend/src/components/FollowingResults.tsx
+++ b/frontend/src/components/FollowingResults.tsx
@@ -60,9 +60,11 @@ export function FollowingResults(props: FollowingResultsProps) {
     );
   }
 
+  const userName = response_data?.data.forUser?.login_name ?? userIdentifier;
+
   return (
     <>
-      <h3 className="text-center text-xl font-semibold text-gray-200 mb-4">Following list for `{response_data?.data.forUser.login_name}`</h3>
+      <h3 className="text-center text-xl font-semibold text-gray-200 mb-4">Following list for `{userName}`</h3>
 
       {response_data?.data && (
         <ResponsiveDataDisplay

--- a/frontend/src/types/Followers.ts
+++ b/frontend/src/types/Followers.ts
@@ -1,7 +1,7 @@
 import { User } from './users';
 
 export interface Follows {
-  forUser: User;
+  forUser?: User;
   follows: Follow[];
 }
 


### PR DESCRIPTION
In order to improve consistency in the usage of the Followers category and route, this commit skips getting a known user from the database when getting followers. Choosing instead to directly use the login when requesting the follower list from 2807's service.